### PR TITLE
Ignore all dotfiles / dotdirs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 /FINJA
 /finja.egg-info/
 *.pyc
+/build
+/dist


### PR DESCRIPTION
This implements filtering "hidden" files and folders, as mentioned in my comment on #8.
